### PR TITLE
Make fetching data as a daily task

### DIFF
--- a/app/services/youtube_data_fetcher.rb
+++ b/app/services/youtube_data_fetcher.rb
@@ -41,6 +41,8 @@ class YoutubeDataFetcher
 
       fetch_comments!(video.video_id, is_generate_markers: true)
     end
+
+    YoutubeVideo.update_description
   end
 
   def fetch_channel!(channel_id)

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -1,0 +1,11 @@
+namespace :youtube do
+  desc 'Queue settlement creation for qualifying balances'
+  task :fetch_recent_videos_with_channel_id => :environment do |_task, args|
+    Rails.logger.info 'START: Updating Youtube Infos.'
+    YoutubeChannel.find_each do | youtube_channel |
+      Rails.logger.info " - Updating..., title: #{youtube_channel.title}"
+      # YoutubeDataFetcher.new.fetch!(youtube_channel.channel_id)
+    end
+    Rails.logger.info 'END: Updating Youtube Infos.'
+  end
+end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -4,7 +4,7 @@ namespace :youtube do
     Rails.logger.info 'START: Updating Youtube Infos.'
     YoutubeChannel.find_each do | youtube_channel |
       Rails.logger.info " - Updating..., title: #{youtube_channel.title}"
-      # YoutubeDataFetcher.new.fetch!(youtube_channel.channel_id)
+      YoutubeDataFetcher.new.fetch!(youtube_channel.channel_id)
     end
     Rails.logger.info 'END: Updating Youtube Infos.'
   end


### PR DESCRIPTION
I run `YoutubeDataFetcher.new.fetch!(YoutubeChannel.take.channel_id)` almost everyday because of updating data.
This PR make it automatic on heroku.