### PR TITLE
Feature: enable to filter by hash-tag

### DIFF
--- a/app/assets/stylesheets/youtube_videos.scss
+++ b/app/assets/stylesheets/youtube_videos.scss
@@ -480,11 +480,19 @@ and (min-resolution:.001dpcm) {
               }
             }
 
-            input {
+            input, select {
               width: 100%;
               height: 2rem;
               font-size: 1rem;
               background: none;
+              border: none;
+              outline: none;
+            }
+
+            select {
+              -webkit-appearance: none;
+              -moz-appearance: none;
+              appearance: none;
               border: none;
               outline: none;
             }

--- a/app/controllers/youtube_videos_controller.rb
+++ b/app/controllers/youtube_videos_controller.rb
@@ -13,6 +13,7 @@ class YoutubeVideosController < ApplicationController
       @videos.order('youtube_videos.published_at DESC, youtube_video_markers.seconds ASC')
     end
 
+    @tags_with_count = @channel.tags_with_count
     @limit = limit
     @marked = video_search_query.present? || marker_search_query.present? || limit.present?
   end
@@ -39,6 +40,13 @@ class YoutubeVideosController < ApplicationController
       like_query = "%#{marker_search_query}%"
       @videos = @videos.where('youtube_video_markers.label LIKE ?', like_query)
     end
+
+    if tag_search_query.present?
+      like_query = "%#{tag_search_query}%"
+      @videos = @videos.where(
+        'youtube_videos.title LIKE ? OR youtube_videos.description LIKE ?', like_query, like_query
+      )
+    end
   end
 
   def video_search_query
@@ -47,6 +55,10 @@ class YoutubeVideosController < ApplicationController
 
   def marker_search_query
     params[:marker_query]
+  end
+
+  def tag_search_query
+    params[:tag_query]
   end
 
   def limit

--- a/app/helpers/youtube_channels_helper.rb
+++ b/app/helpers/youtube_channels_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module YoutubeChannelsHelper
+  def tags_with_count_for_select(tags_with_count)
+    @tags_with_count_for_select ||= tags_with_count.map do |tag, count|
+      tag = tag.gsub('#', '')
+      ["#{tag} (#{count})", tag]
+    end
+  end
+end

--- a/app/models/youtube_channel.rb
+++ b/app/models/youtube_channel.rb
@@ -3,6 +3,34 @@
 class YoutubeChannel < ApplicationRecord
   has_many :videos, class_name: 'YoutubeVideo', foreign_key: 'youtube_channels_id'
 
+  def tags
+    return @tags if @tags.present?
+
+    tmp_tags = []
+    videos.select(:id, :tags).find_each do |video|
+      new_tags = video.tags - tmp_tags
+      tmp_tags += new_tags
+    end
+    tmp_tags.uniq!
+    @tags = tmp_tags
+  end
+
+  def tags_with_count
+    return @tags_with_count if @tags_with_count.present?
+    tags_with_count = {}
+    videos.select(:id, :tags).find_each do |video|
+      video.tags.each do |tag|
+        if tags_with_count[tag]&.integer?
+          tags_with_count[tag] += 1
+        else
+          tags_with_count[tag] = 1
+        end
+      end
+    end
+
+    @tags_with_count = tags_with_count.sort_by(&:last).reverse!
+  end
+
   def fetch!(recursive: true)
     YoutubeDataFetcher.new.fetch!(channel_id, recursive: recursive)
   end

--- a/app/models/youtube_video.rb
+++ b/app/models/youtube_video.rb
@@ -38,7 +38,7 @@ class YoutubeVideo < ApplicationRecord
     ActiveRecord::Base.transaction do
       videos.find_each do |video|
         tags = video.description.scan(/[#＃][\w\p{Han}ぁ-ヶｦ-ﾟー 　']+/).map do |tag|
-          tag.strip.gsub(/　/, '').gsub(/＃/, '#').gsub(/# /, '#')
+          tag.gsub(/　/, '').gsub(/＃/, '#').gsub(/# /, '#').strip
         end
         video.update!(tags: tags)
       rescue StandardError => _e

--- a/app/services/youtube_data_fetcher.rb
+++ b/app/services/youtube_data_fetcher.rb
@@ -43,6 +43,7 @@ class YoutubeDataFetcher
     end
 
     YoutubeVideo.update_description!
+    YoutubeVideo.update_tags!
   end
 
   def fetch_channel!(channel_id)

--- a/app/views/youtube_videos/index.html.erb
+++ b/app/views/youtube_videos/index.html.erb
@@ -127,6 +127,16 @@
             <%= form.text_field :limit, type: :number, value: @limit, placeholder: '100' %>
           </div>
         </div>
+
+        <div class="search-form__row">
+          <div class="search-form__row__label">
+            <%= form.label 'タグから検索:' %>
+          </div>
+          <div class="search-form__row__input">
+            <%= form.select :tag_query, tags_with_count_for_select(@tags_with_count), {prompt: '------', selected: params[:tag_query]}, {} %>
+          </div>
+        </div>
+
         <div class="search-form__row">
           <div class="search-form__row__label">
             <%= form.label 'ランダム:' %>


### PR DESCRIPTION
## Context
YouTuber can add a hash-tag on video description, separatedly from video's tags.
My favorite youtuber uses it to group his videos so I'd like to search by hash-tag.

So this PR enable us to use the Hash Tag to filter the videos.

## What's different between "Tag" and "Hash Tag" on YouTube?
It's a bit complicated but YouTube video can has two types of tags, "Tag" and "Hash Tag".

### Tag
The "Tag" is what we can set when we post a video or start live streaming (Figure: 1).
The YouTube API responds this as the "tags" like `"tags"=>["ゲーム実況", "ゲーム配信", "PS4", "アクション", "Switch"],`.
However, they aren't displayed on user's view. So some YouTubers don't use it.

Figure 1: The input field of "Tags". It doesn't appear on user side.
<img width="300" alt="image" src="https://user-images.githubusercontent.com/4048836/160049799-84b43d80-67d0-4eae-bf17-b59931c05730.png">

### Hash tag
The Hash Tag is what users can see when they see Youtube Videos. (Figure 2)
Unfortunately YouTube API doesn't respond it as the independent field. It's included in "description" field like below.
So we need to extract Hash Tags from description.
```
 "description"=>"#NARUTO　#ナルティメットストーム\nゾンビだあ\n同時配信→　https://bit.ly/2PPuxSX\nhttps://twitter.com/farukonTAKEDA",
```

Figure 2: The "Hash Tag" is from description.
<img width="300" alt="Screen Shot 2022-03-25 at 12 29 56" src="https://user-images.githubusercontent.com/4048836/160048912-cd3bbd73-e5d5-46c5-bdde-a5181f15b3dc.png">